### PR TITLE
Add churn insights analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Churn Prediction Insights
+
+This project contains exploratory analysis for the Telco customer churn dataset. A new script `churn_insights.py` generates summary statistics that highlight churn behavior for each feature.
+
+## Generating insights
+
+Run the script with Python to produce two CSV files in `data/processed`:
+
+```bash
+python3 src/churn_insights.py
+```
+
+The output files are:
+
+- `categorical_churn_rates.csv` – churn rate for every category in categorical features.
+- `numeric_averages_by_churn.csv` – average numeric values grouped by churn label.
+
+These summaries can be useful to detect which customer segments have higher churn probability and how numeric metrics differ between churned and non-churned clients.

--- a/data/processed/categorical_churn_rates.csv
+++ b/data/processed/categorical_churn_rates.csv
@@ -1,0 +1,44 @@
+feature,value,churn_rate
+gender,Female,0.26920871559633025
+gender,Male,0.2616033755274262
+SeniorCitizen,1,0.4168126094570928
+SeniorCitizen,0,0.23606168446026096
+Partner,No,0.32957978577313923
+Partner,Yes,0.1966490299823633
+Dependents,No,0.3127914048246503
+Dependents,Yes,0.15450236966824646
+PhoneService,Yes,0.2670963684955196
+PhoneService,No,0.24926686217008798
+MultipleLines,Yes,0.286098956580276
+MultipleLines,No,0.2504424778761062
+MultipleLines,No phone service,0.24926686217008798
+InternetService,Fiber optic,0.4189276485788114
+InternetService,DSL,0.1895910780669145
+InternetService,No,0.07404980340760157
+OnlineSecurity,No,0.4176672384219554
+OnlineSecurity,Yes,0.14611193660227836
+OnlineSecurity,No internet service,0.07404980340760157
+OnlineBackup,No,0.39928756476683935
+OnlineBackup,Yes,0.21531494442157267
+OnlineBackup,No internet service,0.07404980340760157
+DeviceProtection,No,0.3912762520193861
+DeviceProtection,Yes,0.2250206440957886
+DeviceProtection,No internet service,0.07404980340760157
+TechSupport,No,0.4163547365390153
+TechSupport,Yes,0.15166340508806261
+TechSupport,No internet service,0.07404980340760157
+StreamingTV,No,0.33523131672597867
+StreamingTV,Yes,0.30070188400443293
+StreamingTV,No internet service,0.07404980340760157
+StreamingMovies,No,0.33680430879712747
+StreamingMovies,Yes,0.29941434846266474
+StreamingMovies,No internet service,0.07404980340760157
+Contract,Month-to-month,0.4270967741935484
+Contract,One year,0.11269517990495587
+Contract,Two year,0.02831858407079646
+PaperlessBilling,Yes,0.33565092304003835
+PaperlessBilling,No,0.1633008356545961
+PaymentMethod,Electronic check,0.4528541226215645
+PaymentMethod,Mailed check,0.19106699751861042
+PaymentMethod,Bank transfer (automatic),0.16709844559585493
+PaymentMethod,Credit card (automatic),0.15243101182654403

--- a/data/processed/numeric_averages_by_churn.csv
+++ b/data/processed/numeric_averages_by_churn.csv
@@ -1,0 +1,7 @@
+feature,churn_label,average
+tenure,No,37.56996521066873
+tenure,Yes,17.979133226324237
+MonthlyCharges,No,61.26512369540008
+MonthlyCharges,Yes,74.44133226324237
+TotalCharges,No,2555.344141003293
+TotalCharges,Yes,1531.7960941680042

--- a/src/churn_insights.py
+++ b/src/churn_insights.py
@@ -1,0 +1,70 @@
+import pandas as pd
+from pathlib import Path
+
+DATA_PATH = Path('data/raw/WA_Fn-UseC_-Telco-Customer-Churn.csv')
+
+
+def load_dataset(path: Path) -> pd.DataFrame:
+    """Load and preprocess the churn dataset."""
+    df = pd.read_csv(path)
+    df['TotalCharges'] = pd.to_numeric(df['TotalCharges'], errors='coerce')
+    df['ChurnFlag'] = df['Churn'].map({'Yes': 1, 'No': 0})
+    return df
+
+
+def churn_rate_by_category(df: pd.DataFrame, column: str) -> pd.DataFrame:
+    """Calculate churn rate by categorical column."""
+    return (
+        df.groupby(column)['ChurnFlag']
+        .mean()
+        .reset_index()
+        .rename(columns={column: 'value', 'ChurnFlag': 'churn_rate'})
+        .assign(feature=column)
+        [["feature", "value", "churn_rate"]]
+        .sort_values('churn_rate', ascending=False)
+    )
+
+
+def numeric_average_by_churn(df: pd.DataFrame, column: str) -> pd.DataFrame:
+    """Average numeric column grouped by churn label."""
+    return (
+        df.groupby('Churn')[column]
+        .mean()
+        .reset_index()
+        .rename(columns={'Churn': 'churn_label', column: 'average'})
+        .assign(feature=column)
+        [["feature", "churn_label", "average"]]
+    )
+
+
+def generate_insights(df: pd.DataFrame) -> pd.DataFrame:
+    categorical_cols = [
+        'gender', 'SeniorCitizen', 'Partner', 'Dependents', 'PhoneService',
+        'MultipleLines', 'InternetService', 'OnlineSecurity', 'OnlineBackup',
+        'DeviceProtection', 'TechSupport', 'StreamingTV', 'StreamingMovies',
+        'Contract', 'PaperlessBilling', 'PaymentMethod'
+    ]
+    numeric_cols = ['tenure', 'MonthlyCharges', 'TotalCharges']
+
+    cat_frames = [churn_rate_by_category(df, col) for col in categorical_cols]
+    num_frames = [numeric_average_by_churn(df, col) for col in numeric_cols]
+
+    cat_insights = pd.concat(cat_frames, ignore_index=True)
+    num_insights = pd.concat(num_frames, ignore_index=True)
+
+    return cat_insights, num_insights
+
+
+def main():
+    df = load_dataset(DATA_PATH)
+    cat_insights, num_insights = generate_insights(df)
+
+    output_dir = Path('data/processed')
+    output_dir.mkdir(exist_ok=True)
+    cat_insights.to_csv(output_dir / 'categorical_churn_rates.csv', index=False)
+    num_insights.to_csv(output_dir / 'numeric_averages_by_churn.csv', index=False)
+    print('Insights saved to', output_dir)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- analyze churn dataset in `src/churn_insights.py`
- generate churn-rate summaries for categorical and numeric columns
- document how to create insights in README
- include example CSV outputs

## Testing
- `python3 src/churn_insights.py`

------
https://chatgpt.com/codex/tasks/task_e_685a0a0953fc832ea9f7d07275fdb348